### PR TITLE
Disabled everything except the ship regen overflow fix, seems to still work for Stellaris 3.12.x

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -5,6 +5,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  workflow_dispatch:
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)

--- a/src/dll/dllmain.cpp
+++ b/src/dll/dllmain.cpp
@@ -87,11 +87,11 @@ void thread_idler_testing() {
 	init_address_map();
 
 	// Logging Hooks:
-	ceffect_hook_init(thisPlatform, (intptr_t) p_CApplication_Base, base_augustus_ptr);
-	cevent_hook_init(thisPlatform, (intptr_t) p_CApplication_Base, base_augustus_ptr);
-	crandominlisteffect_hook_init(thisPlatform, (intptr_t) p_CApplication_Base, base_augustus_ptr);
-	conactiondatabase_hook_init(thisPlatform, (intptr_t) p_CApplication_Base, base_augustus_ptr);
-	ceveryinlisteffect_hook_init(thisPlatform, (intptr_t) p_CApplication_Base, base_augustus_ptr);
+	//ceffect_hook_init(thisPlatform, (intptr_t) p_CApplication_Base, base_augustus_ptr);
+	//cevent_hook_init(thisPlatform, (intptr_t) p_CApplication_Base, base_augustus_ptr);
+	//crandominlisteffect_hook_init(thisPlatform, (intptr_t) p_CApplication_Base, base_augustus_ptr);
+	//conactiondatabase_hook_init(thisPlatform, (intptr_t) p_CApplication_Base, base_augustus_ptr);
+	//ceveryinlisteffect_hook_init(thisPlatform, (intptr_t) p_CApplication_Base, base_augustus_ptr);
 	
 	 
 	//Extremely verbose logging Hooks:
@@ -100,8 +100,8 @@ void thread_idler_testing() {
 
 	// Fixes things hooks:
 	//limit_once_in_x_seconds_hook_init(thisPlatform, (intptr_t) p_CApplication_Base, base_augustus_ptr);
-	//cship_hook_init(thisPlatform, (intptr_t)p_CApplication_Base, base_augustus_ptr);
-	assembly_patches_init(thisPlatform, (intptr_t)p_CApplication_Base, base_augustus_ptr);
+	cship_hook_init(thisPlatform, (intptr_t)p_CApplication_Base, base_augustus_ptr);
+	//assembly_patches_init(thisPlatform, (intptr_t)p_CApplication_Base, base_augustus_ptr);
 
 	logger << "Hook init complete, unpausing threads";
 	SetOtherThreadsSuspended(false);


### PR DESCRIPTION
I've disabled everything except the regen overflow fix which at least according to my initial testing (had some trouble triggering overflow at all even without the update since maybe you need to take damage or something so not 100% sure if my testing is valid).   
The other change to cmake.yml is to add a button github actions so I could manually trigger a build.